### PR TITLE
Update twitch v5 api client-id

### DIFF
--- a/TwitchChatVideo/Properties/Resources.Designer.cs
+++ b/TwitchChatVideo/Properties/Resources.Designer.cs
@@ -8891,7 +8891,7 @@ namespace TwitchChatVideo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 96qpeh33rhlnci2bquj2sffoo92hk0.
+        ///   Looks up a localized string similar to kimne78kx3ncx6brgo4mv6wki5h1ko.
         /// </summary>
         internal static string client_id {
             get {

--- a/TwitchChatVideo/Properties/Resources.resx
+++ b/TwitchChatVideo/Properties/Resources.resx
@@ -140,7 +140,7 @@
     <value>..\res\badges\broadcaster-1.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="client_id" xml:space="preserve">
-    <value>96qpeh33rhlnci2bquj2sffoo92hk0</value>
+    <value>kimne78kx3ncx6brgo4mv6wki5h1ko</value>
   </data>
   <data name="clint_fug" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\res\emotes\clint_fug.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
The v5 api comment endpoint is still in use, but only accessible with a new client-id. I'm not sure how long this endpoint is going to stay available, but this should provide at least temporary access while a longer term solution is developed.